### PR TITLE
Port to 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@ plugins {
     // see https://fabricmc.net/develop/ for new versions
     id 'fabric-loom' version '1.10-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.62-beta' apply false
+    id 'net.neoforged.moddev' version '2.0.107' apply false
 }

--- a/common/src/main/java/com/teamremastered/endrem/block/AncientPortalFrameEntity.java
+++ b/common/src/main/java/com/teamremastered/endrem/block/AncientPortalFrameEntity.java
@@ -1,5 +1,6 @@
 package com.teamremastered.endrem.block;
 
+import com.teamremastered.endrem.Constants;
 import com.teamremastered.endrem.EndRemasteredCommon;
 import com.teamremastered.endrem.registry.CommonBlockRegistry;
 import net.minecraft.client.resources.model.Material;
@@ -9,9 +10,13 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
 
 public class AncientPortalFrameEntity  extends BlockEntity {
     private String eye = "empty";
@@ -22,23 +27,25 @@ public class AncientPortalFrameEntity  extends BlockEntity {
     }
 
     @Override
-    protected void saveAdditional(CompoundTag nbt, HolderLookup.Provider provider) {
-        super.saveAdditional(nbt, provider);
-        nbt.putString("eye_inside", this.eye);
+    protected void saveAdditional(ValueOutput output) {
+        super.saveAdditional(output);
+        output.putString("eye_inside", this.eye);
     }
 
     @Override
-    protected void loadAdditional(CompoundTag nbt, HolderLookup.Provider provider) {
-        super.loadAdditional(nbt, provider);
-        this.eye = nbt.getString("eye_inside").orElse("");
+    protected void loadAdditional(ValueInput input) {
+        super.loadAdditional(input);
+        this.eye = input.getString("eye_inside").orElse("");
     }
 
     // Sync With Client
     @Override
     public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        CompoundTag nbt = super.getUpdateTag(registries);
-        saveAdditional(nbt, registries);
-        return nbt;
+        try (ProblemReporter.ScopedCollector problemreporter = new ProblemReporter.ScopedCollector(this.problemPath(), Constants.LOGGER)) {
+            TagValueOutput valueOutput = TagValueOutput.createWithContext(problemreporter, registries);
+            saveAdditional(valueOutput);
+            return valueOutput.buildResult();
+        }
     }
 
     //TODO: Make isEmpty() func

--- a/common/src/main/java/com/teamremastered/endrem/item/EREnderEye.java
+++ b/common/src/main/java/com/teamremastered/endrem/item/EREnderEye.java
@@ -20,7 +20,10 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.EyeOfEnder;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
@@ -32,9 +35,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockPattern;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.BlockHitResult;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
@@ -141,7 +142,7 @@ public class EREnderEye extends Item {
                 if (blockpos != null) {
                     EyeOfEnder eyeofenderentity = new EyeOfEnder(levelIn, playerIn.getX(), playerIn.getY(0.5D), playerIn.getZ());
                     eyeofenderentity.setItem(itemstack);
-                    eyeofenderentity.signalTo(blockpos);
+                    eyeofenderentity.signalTo(blockpos.getCenter());
                     ((EyeOfEnderEntityAccessor) eyeofenderentity).setSurviveAfterDeath(ConfigHandler.EYE_BREAK_PROBABILITY <= playerIn.getRandom().nextInt(100));
 
                     levelIn.addFreshEntity(eyeofenderentity);

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,18 +19,18 @@ minecraft_version_range=[1.21, 1.22)
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.8-20250717.133445
+neo_form_version=1.21.6-20250617.151856
 
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.8
-parchment_version=2025.07.20
+parchment_minecraft=1.21.6
+parchment_version=2025.06.29
 
 # Fabric
-fabric_version=0.133.4+1.21.8
+fabric_version=0.128.2+1.21.6
 fabric_loader_version=0.17.2
 
 # NeoForge
-neoforge_version=21.8.46
+neoforge_version=21.6.20-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ group=com.teamremastered.endrem
 java_version=21
 
 # Common
-minecraft_version=1.21.5
+minecraft_version=1.21.8
 mod_name=End Remastered
 mod_author=Jack Bagel
 mod_id=endrem
@@ -19,18 +19,18 @@ minecraft_version_range=[1.21, 1.22)
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.5-20250325.162830
+neo_form_version=1.21.8-20250717.133445
 
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_minecraft=1.21.4
-parchment_version=2025.03.23
+parchment_minecraft=1.21.8
+parchment_version=2025.07.20
 
 # Fabric
-fabric_version=0.123.0+1.21.5
-fabric_loader_version=0.16.14
+fabric_version=0.133.4+1.21.8
+fabric_loader_version=0.17.2
 
 # NeoForge
-neoforge_version=21.5.65-beta
+neoforge_version=21.8.46
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/neoforge/src/main/java/com/teamremastered/endrem/registry/ERTrades.java
+++ b/neoforge/src/main/java/com/teamremastered/endrem/registry/ERTrades.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
 
 @SuppressWarnings("unused")
-@EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+@EventBusSubscriber(modid = Constants.MOD_ID)
 public class ERTrades {
 
     @SubscribeEvent

--- a/neoforge/src/main/java/com/teamremastered/endrem/registry/RegisterHandler.java
+++ b/neoforge/src/main/java/com/teamremastered/endrem/registry/RegisterHandler.java
@@ -15,7 +15,7 @@ import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
 import net.neoforged.neoforge.registries.*;
 import net.neoforged.bus.api.IEventBus;
 
-@EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = Constants.MOD_ID)
 public class RegisterHandler {
     public static void init(IEventBus modEventBus) {
         GLMS.register(modEventBus);

--- a/neoforge/src/main/java/com/teamremastered/endrem/utils/VanillaLootInjector.java
+++ b/neoforge/src/main/java/com/teamremastered/endrem/utils/VanillaLootInjector.java
@@ -10,7 +10,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AddServerReloadListenersEvent;
 
-@EventBusSubscriber(modid = Constants.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+@EventBusSubscriber(modid = Constants.MOD_ID)
 public class VanillaLootInjector {
     @SubscribeEvent
     public static void resourceReloadListener(AddServerReloadListenersEvent event) {


### PR DESCRIPTION
I've done my best to port everything to 1.21.8. I don't have much experience with Neoforge, so apologies if there are any style/convention issues I didn't know about. Nevertheless, I tested the main features and everything seems to be working fine. 

According to https://github.com/neoforged/FancyModLoader/pull/290, `EventBusSubscriber#bus` is no longer used and has been removed, so it has been removed accordingly here. 

`AncientPortalFrameEntity#getUpdateTag` no longer calls `super.getUpdateTag()` because `saveAdditional` requires a `ValueOutput` which as far as I can tell cannot be created from an existing `CompoundTag`. This shouldn't change any behavior as `BlockEntity#getUpdateTag` simply returns `new CompoundTag()`, but feel free to change it if you have a better solution.

The mod should work on all versions 1.21.6-1.21.8, but the `fabric.mod.json` specifies `~${minecraft_version}`, so would it be preferable for the mod to be developed on 1.21.6 even though 1.21.8 has the newest fixes?

Also, do you want to create a new branch to merge into since the current head is `1.21.5`?